### PR TITLE
Display station buttons in pairs instead of a single column

### DIFF
--- a/public/stations.json
+++ b/public/stations.json
@@ -21,7 +21,7 @@
         {
           "name": "the bootleg boy 2",
           "picture": "the-bootleg-boy-2.webp",
-          "videoId": "ralJmHG-DII"
+          "videoId": "GgbeNFD7l7Q"
         },
         {
           "name": "Afro Lofi",

--- a/src/Components/PlayerControls.jsx
+++ b/src/Components/PlayerControls.jsx
@@ -123,24 +123,48 @@ function PlayerControls({
       {/* Stations Display */}
       <h3 className="title-cat-stat">{intl.formatMessage({ id: "stations" })}</h3>
 
-      {stations.map((station, index) => (
-        <button
-          key={index}
-          onClick={() => onStationChange(station)}
-          className={
-            station.videoId === currentStation.videoId
-              ? "btn-station active-station"
-              : "btn-station"
-          }>
-          <img
-            className="station-picture"
-            src={station.picture}
-            alt={station.name}
-            width={24}
-          />
-          {station.name}
-        </button>
-      ))}
+      <div className="stations-container">
+        {stations.map((station, index) => (
+          index % 2 === 0 ? (
+            <div className="station-row" key={index}>
+              <button
+                onClick={() => onStationChange(station)}
+                className={
+                  station.videoId === currentStation.videoId
+                    ? "btn-station active-station"
+                    : "btn-station"
+                }>
+                <img
+                  className="station-picture"
+                  src={station.picture}
+                  alt={station.name}
+                  width={24}
+                />
+                {station.name}
+              </button>
+
+              {/* Check if there is a next station to form the pair */}
+              {stations[index + 1] && (
+                <button
+                  onClick={() => onStationChange(stations[index + 1])}
+                  className={
+                    stations[index + 1].videoId === currentStation.videoId
+                      ? "btn-station active-station"
+                      : "btn-station"
+                  }>
+                  <img
+                    className="station-picture"
+                    src={stations[index + 1].picture}
+                    alt={stations[index + 1].name}
+                    width={24}
+                  />
+                  {stations[index + 1].name}
+                </button>
+              )}
+            </div>
+          ) : null
+        ))}
+      </div>
 
       {/* Play/Pause Button */}
       <div className="pause-play-buttons">

--- a/src/index.css
+++ b/src/index.css
@@ -217,14 +217,32 @@ button {
   gap: 10px;
 }
 
+.stations-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.station-row {
+  display: flex;
+  justify-content: space-between;
+  width: 80%;
+  margin-bottom: 5px;
+}
+
 .btn-station {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: row;
+  text-align: center;
+  width: 48%;
+  margin-bottom: 5px;
 }
 
 .station-picture {
+  width: 25px;
   margin-right: 8px;
   border-radius: 50px;
 }


### PR DESCRIPTION
**Description:**  
This update modifies the layout of station buttons, grouping them into rows of two instead of displaying them in a single column.  

**Changes:**  
- Wrapped station buttons in a container that aligns them in pairs.  
- Updated JSX logic to ensure buttons are displayed in rows of two.  
- Adjusted CSS to maintain proper spacing and alignment.  

**Why?**  
This change improves the UI by making better use of space and enhancing readability.